### PR TITLE
Subject::lift has incorrect type signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "remap-istanbul": "^0.9.1",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.5",
-    "rxjs": "^5.2.0",
+    "rxjs": "^5.4.0",
     "sinon": "^2.0.0",
     "source-map-support": "^0.4.12",
     "tslint": "^4.5.1",


### PR DESCRIPTION
This issue was fixed on `rxjs` side.

PR: https://github.com/ReactiveX/rxjs/pull/2722 
Issue: https://github.com/ReactiveX/rxjs/issues/2539#issuecomment-313255416