### PR TITLE
Augment Observable interface to overload lift method

### DIFF
--- a/src/RxObservableQuery.ts
+++ b/src/RxObservableQuery.ts
@@ -7,6 +7,12 @@ import { ApolloQueryResult, ObservableQuery } from 'apollo-client';
 
 import { ObservableQueryRef } from './utils/ObservableQueryRef';
 
+declare module 'rxjs/Observable' {
+  interface Observable<T> {
+    lift<R>(operator: Operator<ApolloQueryResult<T>, ApolloQueryResult<R>>): Observable<ApolloQueryResult<R>>;
+  }
+}
+
 export class RxObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
   constructor(
     public apollo: ObservableQuery<any> | ObservableQueryRef,


### PR DESCRIPTION
* Overload lift method allows to override the lift method using
  the derived types from RxObservableQuery.
* Update RxObservableQuery test to use Promises in stub and match
  the Apollo Client's types.